### PR TITLE
Patch dependencies to add Hemi chain data

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,7 +2,7 @@ name: Python CI
 on:
   push:
     branches:
-      - main
+      - hemi-main
       - develop
   pull_request:
   release:
@@ -104,7 +104,7 @@ jobs:
     needs:
       - linting
       - test-app
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || (github.event_name == 'release' && github.event.action == 'released')
+    if: github.ref == 'refs/heads/hemi-main' || github.ref == 'refs/heads/develop' || (github.event_name == 'release' && github.event.action == 'released')
     steps:
     - uses: actions/checkout@v4
     - uses: docker/setup-qemu-action@v3
@@ -114,16 +114,16 @@ jobs:
     - name: Dockerhub login
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Deploy Master
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/hemi-main'
       uses: docker/build-push-action@v5
       with:
         context: .
         file: docker/web/Dockerfile
         push: true
-        tags: safeglobal/safe-transaction-service:staging
+        tags: hemilabs/safe-transaction-service:staging
         platforms: |
           linux/amd64
           linux/arm64
@@ -136,7 +136,7 @@ jobs:
         context: .
         file: docker/web/Dockerfile
         push: true
-        tags: safeglobal/safe-transaction-service:develop
+        tags: hemilabs/safe-transaction-service:develop
         platforms: |
           linux/amd64
           linux/arm64
@@ -150,8 +150,8 @@ jobs:
         file: docker/web/Dockerfile
         push: true
         tags: |
-          safeglobal/safe-transaction-service:${{ github.event.release.tag_name }}
-          safeglobal/safe-transaction-service:latest
+          hemilabs/safe-transaction-service:${{ github.event.release.tag_name }}
+          hemilabs/safe-transaction-service:latest
         platforms: |
           linux/amd64
           linux/arm64
@@ -160,7 +160,8 @@ jobs:
   autodeploy:
     runs-on: ubuntu-latest
     needs: [docker-deploy]
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    # if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    if: false 
     steps:
     - uses: actions/checkout@v4
     - name: Deploy Staging

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -18,11 +18,16 @@ RUN set -ex \
 		" \
     && apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends $buildDeps tmux postgresql-client \
+    && apt-get install -y --no-install-recommends $buildDeps tmux postgresql-client patch \
     && pip install -U --no-cache-dir wheel setuptools pip \
     && pip install --no-cache-dir -r requirements.txt \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -rf /var/lib/apt/lists/*
+
+# Patch safe-eth-py with Hemi data now so we don't need to wait for the package
+# to be published.
+COPY patches patches
+RUN patch -d ../usr/local/lib/python3.12/site-packages -p1 -N < patches/safe_eth_py-6.0.0b29.patch 
 
 # /nginx mount point must be created before so it doesn't have root permissions
 # ${APP_HOME} root folder will not be updated by COPY --chown, so permissions need to be adjusted

--- a/patches/safe_eth_py-6.0.0b29.patch
+++ b/patches/safe_eth_py-6.0.0b29.patch
@@ -1,0 +1,113 @@
+diff --git a/gnosis/eth/ethereum_network.py b/gnosis/eth/ethereum_network.py
+index 8686ba6..f26f6af 100644
+--- a/gnosis/eth/ethereum_network.py
++++ b/gnosis/eth/ethereum_network.py
+@@ -1114,6 +1114,7 @@ class EthereumNetwork(Enum):
+     VISION_VPIONEER_TEST_CHAIN = 666666
+     HELA_OFFICIAL_RUNTIME_TESTNET = 666888
+     SEI_DEVNET = 713715
++    HEMI_SEP = 743111
+     BEAR_NETWORK_CHAIN_TESTNET = 751230
+     MIEXS_SMARTCHAIN = 761412
+     MODULARIUM = 776877
+diff --git a/gnosis/safe/addresses.py b/gnosis/safe/addresses.py
+index 1a4d131..d3382ef 100644
+--- a/gnosis/safe/addresses.py
++++ b/gnosis/safe/addresses.py
+@@ -522,6 +522,10 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
+             "1.3.0",
+         ),  # Safe singleton address
+     ],
++    EthereumNetwork.HEMI_SEP: [
++        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 827598, "1.3.0+L2"),
++        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 827600, "1.3.0"),
++    ],
+     EthereumNetwork.TENET_TESTNET: [
+         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 885391, "1.3.0+L2"),
+         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 885392, "1.3.0"),
+@@ -1419,6 +1423,9 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
+             2086864,
+         ),  # v1.3.0  Default singleton address
+     ],
++    EthereumNetwork.HEMI_SEP: [
++        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 827584),  # v1.3.0
++    ],
+     EthereumNetwork.TENET_TESTNET: [
+         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 885379),  # v1.3.0
+     ],
+diff --git a/gnosis/safe/safe_deployments.py b/gnosis/safe/safe_deployments.py
+index 99226c6..44d3d55 100644
+--- a/gnosis/safe/safe_deployments.py
++++ b/gnosis/safe/safe_deployments.py
+@@ -285,6 +285,7 @@ safe_deployments = {
+             "534353": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
+             "622277": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+             "713715": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
++            "743111": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+             "6038361": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
+             "7777777": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4",
+             "11155111": "0x017062a1dE2FE6b99BE3d9d37841FeD19F573804",
+@@ -501,6 +502,7 @@ safe_deployments = {
+             "534353": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
+             "622277": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+             "713715": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
++            "743111": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+             "6038361": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
+             "7777777": "0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4",
+             "11155111": "0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d",
+@@ -717,6 +719,7 @@ safe_deployments = {
+             "534353": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
+             "622277": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+             "713715": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
++            "743111": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+             "6038361": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
+             "7777777": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+             "11155111": "0x69f4D1788e39c87893C980c06EdF4b7f686e2938",
+@@ -933,6 +936,7 @@ safe_deployments = {
+             "534353": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+             "622277": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+             "713715": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
++            "743111": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+             "6038361": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+             "7777777": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+             "11155111": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+@@ -1149,6 +1153,7 @@ safe_deployments = {
+             "534353": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
+             "622277": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+             "713715": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
++            "743111": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+             "6038361": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
+             "7777777": "0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761",
+             "11155111": "0x998739BFdAAdde7C933B942a68053933098f9EDa",
+@@ -1365,6 +1370,7 @@ safe_deployments = {
+             "534353": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
+             "622277": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+             "713715": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
++            "743111": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+             "6038361": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
+             "7777777": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+             "11155111": "0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B",
+@@ -1581,6 +1587,7 @@ safe_deployments = {
+             "534353": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+             "622277": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+             "713715": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
++            "743111": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+             "6038361": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+             "7777777": "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+             "11155111": "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+@@ -1797,6 +1804,7 @@ safe_deployments = {
+             "534353": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
+             "622277": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+             "713715": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
++            "743111": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+             "6038361": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
+             "7777777": "0xA65387F16B013cf2Af4605Ad8aA5ec25a2cbA3a2",
+             "11155111": "0x98FFBBF51bb33A056B08ddf711f289936AafF717",
+@@ -2013,6 +2021,7 @@ safe_deployments = {
+             "534353": "0x727a77a074D1E6c4530e814F89E618a3298FC044",
+             "622277": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+             "713715": "0x727a77a074D1E6c4530e814F89E618a3298FC044",
++            "743111": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+             "6038361": "0x727a77a074D1E6c4530e814F89E618a3298FC044",
+             "7777777": "0x59AD6735bCd8152B84860Cb256dD9e96b85F69Da",
+             "11155111": "0x727a77a074D1E6c4530e814F89E618a3298FC044",


### PR DESCRIPTION
### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [x] You ran `pre-commit run -a`
- [x] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

Hemi Sepolia was not supported.

### How was it fixed? 🎯

This PR adds the `patch` command to the Docker image and applies a patch after the Python dependencies are installed. The patch modifies files in `safe-eth-py` to add the Hemi Sepolia network slug, id and deployed contract addresses. Doing so allows building the Docker images without waiting for upstream to update the dependencies.

It also updates the Docker build pipeline to push the images to the `hemilabs` organization.